### PR TITLE
crossOrigin property for loadable background image

### DIFF
--- a/src/plugins/background-image/BackgroundImage.js
+++ b/src/plugins/background-image/BackgroundImage.js
@@ -249,7 +249,9 @@
           };
         }
 
-        image.crossOrigin = "Anonymous"
+        if (options.crossOrigin) {
+          image.crossOrigin = options.crossOrigin
+        }
         // this will start creating image
         image.src = imageSrc;
     };

--- a/src/plugins/background-image/BackgroundImage.js
+++ b/src/plugins/background-image/BackgroundImage.js
@@ -249,6 +249,7 @@
           };
         }
 
+        image.crossOrigin = "Anonymous"
         // this will start creating image
         image.src = imageSrc;
     };

--- a/src/plugins/background-image/BackgroundImage.js
+++ b/src/plugins/background-image/BackgroundImage.js
@@ -250,7 +250,7 @@
         }
 
         if (options.crossOrigin) {
-          image.crossOrigin = options.crossOrigin
+          image.crossOrigin = options.crossOrigin;
         }
         // this will start creating image
         image.src = imageSrc;


### PR DESCRIPTION
We are use remote storage for bg images. We can't drawing without it. This changes solve my problem.

Example of usage
```
drawer.api.setBackgroundImageFromUrl($editor.data('src'), {
  imagePosition: 'top-left',
  imgWidth: imgSizes.width,
  imgHeight: imgSizes.height,
  crossOrigin: 'Anonymous'
})
```
 